### PR TITLE
Replace `identifierNotFUNCTION` with `identifier`.

### DIFF
--- a/tools/spec_parser/Dart.g
+++ b/tools/spec_parser/Dart.g
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // CHANGES:
+// v0.31 Inline `identifierNotFUNCTION` into `identifier`. Replace all
+// other references with `identifier` to match the spec.
 //
 // v0.30 Add support for the class modifiers `sealed`, `final`, `base`,
 // `interface`, and for `mixin class` declarations. Also add support for
@@ -280,7 +282,7 @@ initializedIdentifierList
     ;
 
 functionSignature
-    :    type? identifierNotFUNCTION formalParameterPart
+    :    type? identifier formalParameterPart
     ;
 
 functionBody
@@ -337,7 +339,7 @@ normalFormalParameterNoMetadata
 
 // NB: It is an anomaly that a functionFormalParameter cannot be FINAL.
 functionFormalParameter
-    :    COVARIANT? type? identifierNotFUNCTION formalParameterPart '?'?
+    :    COVARIANT? type? identifier formalParameterPart '?'?
     ;
 
 simpleFormalParameter
@@ -997,16 +999,11 @@ assignableSelector
     |    '?' '[' expression ']'
     ;
 
-identifierNotFUNCTION
+identifier
     :    IDENTIFIER
     |    builtInIdentifier
     |    otherIdentifier
     |    { asyncEtcPredicate(getCurrentToken().getType()) }? (AWAIT|YIELD)
-    ;
-
-identifier
-    :    identifierNotFUNCTION
-    |    FUNCTION // Built-in identifier that can be used as a type.
     ;
 
 qualifiedName


### PR DESCRIPTION
Inline `identifierNotFUNCTION` into `identifier`.
Replace other references with `identifier` to match the spec.


### functionSignature

antlr-based spec today:
https://github.com/dart-lang/sdk/blob/b1b1f47b958228ec082fbcb19d4e56787ff1d418/tools/spec_parser/Dart.g#L282-L284

latex-based spec today:
https://github.com/dart-lang/language/blob/2a3a253ca81d3cf0b78ad88e34aaaf6e185b5345/specification/dartLangSpec.tex#L1580-L1581

### functionFormalParameter

antlr-based spec today:
https://github.com/dart-lang/sdk/blob/b1b1f47b958228ec082fbcb19d4e56787ff1d418/tools/spec_parser/Dart.g#L339-L341

latex-based spec today:
https://github.com/dart-lang/language/blob/2a3a253ca81d3cf0b78ad88e34aaaf6e185b5345/specification/dartLangSpec.tex#L1973-L1976

Closes: #51674